### PR TITLE
Make it run on Windows 10 (build 1903)

### DIFF
--- a/Image.cpp
+++ b/Image.cpp
@@ -6,8 +6,28 @@
 #include "lib\utils.hpp"
 #include "File.h"
 
+void TryInitSDL()
+{
+	static bool SDL_initialized = false;
+	if (!SDL_initialized)
+	{
+		SDL_initialized = true;
+		if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+			log_format("ERROR: Failed to initialize SDL video (%s)\n", SDL_GetError());
+			return;
+		}
+		if (IMG_Init(IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF) !=
+			(IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF)) {
+			log_format("ERROR: Failed to initialize SDL image (%s)\n", IMG_GetError());
+			return;
+		}
+	}
+}
+
 Image::Image(std::string filename)
 {
+	TryInitSDL();
+	
 	myPixels = NULL;
 	myWidth = 0;
 	myHeight = 0;

--- a/Image.cpp
+++ b/Image.cpp
@@ -5,37 +5,7 @@
 #include "zxmgr.h"
 #include "lib\utils.hpp"
 #include "File.h"
-
-bool SDLInitialized = false;
-HANDLE SDLInitMutex = NULL;
-
-void InitSDL()
-{
-	if (SDL_Init(SDL_INIT_VIDEO) != 0) {
-		log_format("ERROR: Failed to initialize SDL video (%s)\n", SDL_GetError());
-		return;
-	}
-	if (IMG_Init(IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF) !=
-		(IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF)) {
-		log_format("ERROR: Failed to initialize SDL image (%s)\n", IMG_GetError());
-		return;
-	}
-}
-
-void TryInitSDL()
-{
-	if (!SDLInitialized)
-	{
-		if (!SDLInitMutex) SDLInitMutex = CreateMutex(NULL, TRUE, NULL);
-		else WaitForSingleObject(SDLInitMutex, INFINITE);
-		if (!SDLInitialized)
-		{
-			InitSDL();
-			SDLInitialized = true;
-		}
-		ReleaseMutex(SDLInitMutex);
-	}
-}
+#include "a2mgr.h"
 
 Image::Image(std::string filename)
 {

--- a/a2mgr.cpp
+++ b/a2mgr.cpp
@@ -60,6 +60,36 @@ string DumpSHA(unsigned char buf[])
 	return string2;
 }
 
+bool SDLInitialized = false;
+HANDLE SDLInitMutex = NULL;
+void InitSDL()
+{
+	if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+		log_format("ERROR: Failed to initialize SDL video (%s)\n", SDL_GetError());
+		return;
+	}
+	if (IMG_Init(IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF) !=
+		(IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF)) {
+		log_format("ERROR: Failed to initialize SDL image (%s)\n", IMG_GetError());
+		return;
+	}
+}
+
+void TryInitSDL()
+{
+	if (!SDLInitialized)
+	{
+		if (!SDLInitMutex) SDLInitMutex = CreateMutex(NULL, TRUE, NULL);
+		else WaitForSingleObject(SDLInitMutex, INFINITE);
+		if (!SDLInitialized)
+		{
+			InitSDL();
+			SDLInitialized = true;
+		}
+		ReleaseMutex(SDLInitMutex);
+	}
+}
+
 bool _stdcall DllMain_Init(HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
 	//__network_ext_Initialize();

--- a/a2mgr.h
+++ b/a2mgr.h
@@ -6,3 +6,5 @@ extern unsigned long u_pid;
 
 extern char* u_pid_string;
 extern char* u_pid_string_delete;
+
+void TryInitSDL();


### PR DESCRIPTION
Possible SDL_Init() deadlock when called during DLL initialization (not sure about this, but provided fix should work).
Initialize SDL on-demand instead (for example, in Image::Image() constructor).