### PR TITLE
Delete all *.a2c files on startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project(a2mgr)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 link_libraries(ws2_32)

--- a/a2mgr.cpp
+++ b/a2mgr.cpp
@@ -4,6 +4,7 @@
 #include "debug.h"
 #include <cstring>
 #include <ctime>
+#include <filesystem>
 
 #include "a2mgr.h"
 
@@ -87,6 +88,21 @@ void TryInitSDL()
 		}
 		ReleaseMutex(SDLInitMutex);
 	}
+}
+
+void RemoveA2C() {
+    try {
+        int count;
+        for (const auto& entry : std::filesystem::directory_iterator(".")) {
+            if (entry.is_regular_file() && entry.path().extension() == ".a2c") {
+                std::filesystem::remove(entry.path());
+                ++count;
+            }
+        }
+        log_format("Deleted %d `.a2c` files\n", count);
+    } catch (const std::exception& e) {
+        log_format("Failed to delete `.a2c` files: %s\n", e.what());
+    }
 }
 
 bool _stdcall DllMain_Init(HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
@@ -203,6 +219,8 @@ bool _stdcall DllMain_Init(HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID l
 				Sleep(delay); // before we try to initialize video mode, etc. to not make the old allods be like wtf.
 		}
 	}
+
+	RemoveA2C();
 
 	return true;
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -3,14 +3,14 @@
 #include <cstdarg>
 #include <cstdio>
 
-using namespace std;
-
 #include <windows.h>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <string>
 #include <vector>
+
+using namespace std;
 
 ofstream _LOG_FILE;
 string   _LOG_NAME;


### PR DESCRIPTION
When a character is renamed from hat or from circling to hell, the user needs to remove locally cached corresponding character file. This file has the character name that the client sends to the hat. We're deleting the cached files, and the game re-downloads them from hat upon login.