### PR TITLE
Don't delete `.a2c` files

### DIFF
--- a/a2mgr.cpp
+++ b/a2mgr.cpp
@@ -87,28 +87,6 @@ void TryInitSDL()
 	}
 }
 
-void RemoveA2C() {
-	int count = 0;
-	WIN32_FIND_DATAA directory;
-	HANDLE find = FindFirstFileA("*.a2c", &directory);
-
-	if (find != INVALID_HANDLE_VALUE) {
-		do {
-			if (!(directory.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-				if (DeleteFileA(directory.cFileName)) {
-					++count;
-				} else {
-					log_format("Failed to delete %s\n", directory.cFileName);
-				}
-			}
-		} while (FindNextFileA(find, &directory));
-
-		FindClose(find);
-	}
-
-	log_format("Deleted %d `.a2c` files\n", count);
-}
-
 bool _stdcall DllMain_Init(HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
 {
 	//__network_ext_Initialize();
@@ -223,8 +201,6 @@ bool _stdcall DllMain_Init(HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID l
 				Sleep(delay); // before we try to initialize video mode, etc. to not make the old allods be like wtf.
 		}
 	}
-
-	RemoveA2C();
 
 	return true;
 }


### PR DESCRIPTION
Breaks re-entering after a disconnect. Maybe we should delete files only on a "regular" login, but that's for later.