### PR TITLE
Grey out the servers that the character won't be able to enter

### DIFF
--- a/config.cpp
+++ b/config.cpp
@@ -50,6 +50,7 @@ unsigned char sha1_uuid[20];
 int z_softcore = 0;
 
 bool hotkey_debug = false;
+bool stats_based_level_selection = true;
 
 using namespace std;
 
@@ -213,6 +214,12 @@ void ParseConfig2x(ifstream& f_temp)
                 hotkey_debug = StrToBoolean(cmd[1]);
             } else {
                 hotkey_debug = true;
+            }
+        } else if (cmd[0] == "stats_based_level_selection") {
+            if (cmd.size() == 2) {
+                stats_based_level_selection = StrToBoolean(cmd[1]);
+            } else {
+                stats_based_level_selection = true;
             }
         }
     }

--- a/config.h
+++ b/config.h
@@ -55,6 +55,7 @@ extern std::string current_directory;
 extern int z_softcore;
 
 extern bool hotkey_debug;
+extern bool stats_based_level_selection;
 
 #define PROTO_VER 20
 


### PR DESCRIPTION
This parses the server number from the server name that's sent by hat. The server name should start with `#4` for server 4.

If this feature bugs out, it can prevent players from joining any server. Can be disabled with `stats_based_level_selection false` in the config.